### PR TITLE
Added freenome-build db options for databases in Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Packaging, build, and development tools.
 Manage a test postgres DB in a Docker container. This also runs a DB setup script and DB migrations. The structure of the setup and migrations scripts is described in more detail in the  [README](./freenome_build/database_template/README.md)
 
 ## freenome-build db start-local-test-db
-Start a test DB with test data. Returns a connection string to stdout
+Start a local test DB with test data. Returns a connection string to stdout
 
-## freenome-build db stop 
-Stop a test DB.
+## freenome-build db stop-local
+Stop a local test DB.
 
 ## freenome-build develop
 Setup a conda development environment for the current repo.

--- a/freenome_build/database_template/README.md
+++ b/freenome_build/database_template/README.md
@@ -2,11 +2,9 @@
 
 ## Local testing Database
 
-### Quick Start
-
 Start a local test database
 ```
-freenome-build db start
+freenome-build db start-local
 ```
 
 Start a test database, run migrations, and insert test data
@@ -22,7 +20,7 @@ freenome-build db --conn-string postgresql://{dbuser}:{password}@{host}:{port}/{
 
 Stop a test database
 ```
-freenome-build db --conn-string postgresql://{dbuser}:{password}@{host}:{port}/{dbname} stop
+freenome-build db --conn-string postgresql://{dbuser}:{password}@{host}:{port}/{dbname} stop-local
 ```
 
 Insert test data into the test database
@@ -33,6 +31,28 @@ freenome-build db --conn-string postgresql://{dbuser}:{password}@{host}:{port}/{
 Reset the data inside the test database (Does not require rerunning migrations)
 ```
 freenome-build db --conn-string postgresql://{dbuser}:{password}@{host}:{port}/{dbname} reset-data
+```
+
+## Kubernetes Testing Database
+
+Start a test database in a kubernetes pod.
+```
+freenome-build db start-k8s
+```
+
+Start a test database in a kubernetes pod, run migrations, and insert test data:
+Note: This needs to be run from another container in the same pod so that the database container is reachable through its IP
+```
+freenome-build db start-k8s-test-db
+```
+
+Stop a test database that is running in a kubernetes pod
+```
+freenome-build db --pod_id {pod_id} stop-k8s
+```
+or
+```
+freenome-build db --host {pod_ip} stop-k8s
 ```
 
 ### Database Management Template Scripts

--- a/freenome_build/database_template/README.md
+++ b/freenome_build/database_template/README.md
@@ -35,12 +35,12 @@ freenome-build db --conn-string postgresql://{dbuser}:{password}@{host}:{port}/{
 
 ## Kubernetes Testing Database
 
-Start a test database in a kubernetes pod.
+Start a test database in a kubernetes pod. There is an optional kube-pod-config option here that you can use to specify your own Pod config. Otherwise, the default in database_template is used
 ```
 freenome-build db start-k8s
 ```
 
-Start a test database in a kubernetes pod, run migrations, and insert test data:
+Start a test database in a kubernetes pod, run migrations, and insert test data. There is an optional kube-pod-config option here that you can use to specify your own Pod config. Otherwise, the default in database_template is used
 Note: This needs to be run from another container in the same pod so that the database container is reachable through its IP
 ```
 freenome-build db start-k8s-test-db

--- a/freenome_build/database_template/db_pod_config.yaml
+++ b/freenome_build/database_template/db_pod_config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: test-freenome-db-
+spec:
+  restartPolicy: Never
+  containers:
+  - name: database
+    image: postgres:9.6
+  

--- a/freenome_build/database_template/db_pod_config.yaml
+++ b/freenome_build/database_template/db_pod_config.yaml
@@ -7,4 +7,3 @@ spec:
   containers:
   - name: database
     image: postgres:9.6
-  

--- a/freenome_build/db.py
+++ b/freenome_build/db.py
@@ -5,7 +5,9 @@ import socket
 import subprocess
 import string
 import time
+from typing import Tuple
 
+import json
 import psycopg2
 from contextlib import closing
 from urllib.parse import urlparse
@@ -14,8 +16,11 @@ from freenome_build.util import norm_abs_join_path, change_directory, get_git_re
 
 logger = logging.getLogger(__file__)  # noqa: invalid-name
 
-# the maximum amount of time in seconds to wait for the DB to come up before raising an error
+# the maximum amount of time in seconds to wait for a local DB to come up before raising an error
 MAX_DB_WAIT_TIME = 10
+
+# The maximum amount of time in seconds to wait for a k8s db to come up.
+MAX_CONTAINER_CHECKS = 600
 
 
 class DbConnectionData():
@@ -109,6 +114,38 @@ def _wait_for_db_cluster_to_start(host: str, port: int, max_wait_time=MAX_DB_WAI
     raise RuntimeError(f"Aborting because the DB did not start within {MAX_DB_WAIT_TIME} seconds.")
 
 
+def _wait_for_container(pod_id: str):
+    last_timestamp = ""
+    event_cmd = f"kubectl get events -o json --sort-by=.metadata.creationTimestamp " \
+                f"--field-selector involvedObject.name={pod_id}"
+    pod_status_cmd = f"kubectl get pod {pod_id}"
+    attempts = 0
+    while attempts < MAX_CONTAINER_CHECKS:
+        # We need to do this separately from checking for events since the
+        # "Started" event doesn't necessarily mean the pod is ready.
+        pod_status = subprocess.check_output(pod_status_cmd, shell=True).decode().strip()
+        if 'Running' in pod_status:
+            return
+        # If the pod isn't running yet, check for any new events.
+        events = json.loads(subprocess.check_output(event_cmd, shell=True).decode().strip())['items']
+        for event in events:
+            # If this is a new event, log it.
+            if last_timestamp < event['firstTimestamp']:
+                logger.info(f"Container status: {event['message']}")
+            # If there was an error, raise an exception
+            if 'Error' in event['message']:
+                raise RuntimeError(f"Container failed to start: {event['message']}")
+        if len(events) > 0:
+            last_timestamp = events[-1]['firstTimestamp']
+        time.sleep(1)
+    raise RuntimeError(f"Container failed to start after {MAX_CONTAINER_CHECKS} seconds")
+
+
+def _get_pod_id_from_pod_ip(pod_ip: str) -> str:
+    get_id_cmd = f"kubectl get pods --output jsonpath=\"{{.items[?(.status.podIP=='{pod_ip}')].metadata.name}}\""
+    return subprocess.check_output(get_id_cmd, shell=True).decode().strip()
+
+
 def start_local_database(repo_path: str, project_name: str, port: int = None, password: str = None) -> DbConnectionData:
     """Start a test database in a docker container.
 
@@ -154,6 +191,28 @@ def start_local_database(repo_path: str, project_name: str, port: int = None, pa
     conn_data = DbConnectionData(host, port, dbname, user, password)
 
     return conn_data
+
+
+def start_k8s_database(repo_path: str, project_name: str, password: str = None,
+                       kube_pod_config: str = None) -> Tuple[DbConnectionData, str]:
+    dbname = project_name
+    user = project_name
+    port = 5432
+
+    if kube_pod_config is None:
+        kube_pod_config = norm_abs_join_path(
+            os.path.dirname(__file__), "./database_template/db_pod_config.yaml")
+    kcreate_cmd = f"kubectl create -f {kube_pod_config} | sed 's/pod \"\|\" created//g'"
+    pod_id = subprocess.check_output(kcreate_cmd, shell=True).decode().strip()
+
+    _wait_for_container(pod_id)
+
+    # Get the pod's IP for the db host
+    pod_ip_cmd = f"kubectl describe pod {pod_id} | grep IP | sed -E 's/IP:[[:space:]]+//'"
+    host = subprocess.check_output(pod_ip_cmd, shell=True).decode().strip()
+
+    conn_data = DbConnectionData(host, port, dbname, user, password)
+    return conn_data, pod_id
 
 
 def setup_db(conn_data: DbConnectionData, repo_path: str) -> None:
@@ -254,10 +313,25 @@ def stop_local_database(conn_data: DbConnectionData) -> None:
     run_and_log(cmd)
 
 
+def stop_k8s_database(pod_id: str) -> None:
+    run_and_log(f"kubectl delete pod {pod_id}")
+
+
 def start_local_database_main(args):
     conn_data = start_local_database(args.path, args.project_name, port=args.port)
     logger.info(f"Successfully started a database. Use the following string to connect:")
     print(conn_data)
+
+
+def start_k8s_database_main(args):
+    if args.conn_data:
+        conn_data, pod_id = start_k8s_database(args.path, args.conn_data.dbname,
+                                               port=args.conn_data.port, kube_pod_config=args.kube_pod_config)
+    else:
+        conn_data, pod_id = start_k8s_database(args.path, args.project_name, kube_pod_config=args.kube_pod_config)
+    logger.info(f"Successfully started a database. Connect to {pod_id} and use the following string to connect:")
+    print(conn_data)
+    print(pod_id)
 
 
 def start_local_test_database_main(args):
@@ -270,6 +344,22 @@ def start_local_test_database_main(args):
     insert_test_data(conn_data, args.path)
     logger.info(f"Successfully started a database. Use the following string to connect:")
     print(conn_data)
+
+
+def start_k8s_test_database_main(args):
+    # This option needs to be called from within a kubernetes container
+    # because this machine needs to be able communicate with the pod
+    # that's created
+    if args.conn_data:
+        conn_data, pod_id = start_k8s_database(args.path, args.conn_data.dbname,
+                                               port=args.conn_data.port, kube_pod_config=args.kube_pod_config)
+    else:
+        conn_data, pod_id = start_k8s_database(args.path, args.project_name, kube_pod_config=args.kube_pod_config)
+    setup_db(conn_data, args.path)
+    insert_test_data(conn_data, args.path)
+    logger.info(f"Successfully started a database. Connect to {pod_id} and use the following string to connect:")
+    print(conn_data)
+    print(pod_id)
 
 
 def setup_db_main(args):
@@ -296,17 +386,29 @@ def stop_local_database_main(args):
     stop_local_database(args.conn_data)
 
 
+def stop_k8s_database_main(args):
+    if args.pod_id:
+        pod_id = args.pod_id
+    elif args.conn_data:
+        pod_id = _get_pod_id_from_pod_ip(args.conn_data.host)
+    elif args.host:
+        pod_id = _get_pod_id_from_pod_ip(args.host)
+    else:
+        raise RuntimeError("Please specify a pod_id or host IP")
+    stop_k8s_database(pod_id)
+
+
 def add_db_subparser(subparsers):
     database_parser = subparsers.add_parser('db', help='manage the test database')
     database_parser.required = True
     database_parser.add_argument('--path', default='.')
     database_parser.add_argument(
-        '--port', type=int,
-        help='Port on which to start the test db. Default is a random free port'
+        '--host', type=str,
+        help='The host that is running the database'
     )
     database_parser.add_argument(
-        '--host', default='localhost',
-        help='Test DB host. Default: %(default)s'
+        '--port', type=int,
+        help='Port on which to start the test db. Default is a random free port'
     )
     database_parser.add_argument(
         '--password', default=None,
@@ -323,16 +425,31 @@ def add_db_subparser(subparsers):
         '--conn-string', default=None,
         help='The postgres connection string that can be used to connect to the db'
     )
+    database_parser.add_argument(
+        '--kube-pod-config', default=None,
+        help='The pod config to use for a kubernetes db. Defaults to the basic template in ./database_template'
+    )
+    database_parser.add_argument(
+        '--pod_id', default=None,
+        help='The pod id that will be used when stopping a database. This is only used in stoppnig a database.'
+    )
 
     # add the subparsers
     database_subparsers = database_parser.add_subparsers(dest='test_db_command')
     database_subparsers.required = True
 
     # Start a DB
-    database_subparsers.add_parser('start', help='Start a database')
+    database_subparsers.add_parser('start-local', help='Start a local database')
+
+    # Start a DB
+    database_subparsers.add_parser('start-k8s', help='Start a database in a Kubernetes pod')
 
     # Start a test DB, run migrations, insert the starting data
     database_subparsers.add_parser('start-local-test-db', help='Start a database with all the default data')
+
+    # Start a test DB, run migrations, insert the starting data
+    database_subparsers.add_parser('start-k8s-test-db',
+                                   help='Start a database with all the default data in a kubernetes pod')
 
     # Run the sqitch migrations on the database
     database_subparsers.add_parser('setup-db', help='Create database and run migrations on database schemas')
@@ -346,7 +463,10 @@ def add_db_subparser(subparsers):
                                    'Requires inserting the test data afterwards.')
 
     # Stop the test db
-    database_subparsers.add_parser('stop', help='stop the test database')
+    database_subparsers.add_parser('stop-local', help='Stop the local test database')
+
+    # Stop the test db
+    database_subparsers.add_parser('stop-k8s', help='Stop the kubernetes test database')
 
 
 def db_main(args):
@@ -363,17 +483,23 @@ def db_main(args):
     else:
         args.conn_data = None
 
-    if args.test_db_command == 'start':
+    if args.test_db_command == 'start-local':
         start_local_database_main(args)
+    if args.test_db_command == 'start-k8s':
+        start_k8s_database_main(args)
     elif args.test_db_command == 'start-local-test-db':
         start_local_test_database_main(args)
+    elif args.test_db_command == 'start-k8s-test-db':
+        start_k8s_test_database_main(args)
     elif args.test_db_command == 'setup-db':
         setup_db_main(args)
     elif args.test_db_command == 'insert-test-data':
         insert_test_data_main(args)
     elif args.test_db_command == 'reset-data':
         reset_data_main(args)
-    elif args.test_db_command == 'stop':
+    elif args.test_db_command == 'stop-local':
         stop_local_database_main(args)
+    elif args.test_db_command == 'stop-k8s':
+        stop_k8s_database_main(args)
     else:
         raise ValueError(f"Unrecognized DB subcommand '{args.test_db_command}'")

--- a/tests/test_test_db.py
+++ b/tests/test_test_db.py
@@ -78,6 +78,8 @@ def _test_k8s_connection(testing_pod_id: str, conn_data: DbConnectionData):
                 f"-p {conn_data.port} -U {conn_data.user} -d {conn_data.dbname}")
 
 
+# TODO(travis_service_account)
+@pytest.mark.skip(reason="There's no google service account for travis yet")
 def test_k8s_db_cli():
     try:
         start_cmd = f"freenome-build db start-k8s"
@@ -102,6 +104,8 @@ def test_k8s_db_cli():
         run_and_log(stop_cmd)
  
 
+# TODO(travis_service_account)
+@pytest.mark.skip(reason="There's no google service account for travis yet")
 def test_k8s_db_interface():
     try:
         conn_data, pod_id1 = start_k8s_database(DB_DIR, 'freenome_build')

--- a/tests/test_test_db.py
+++ b/tests/test_test_db.py
@@ -79,7 +79,8 @@ def _test_k8s_connection(testing_pod_id: str, conn_data: DbConnectionData):
 
 
 # TODO(travis_service_account)
-@pytest.mark.skip(reason="There's no google service account for travis yet")
+@pytest.mark.skipif('TRAVIS' in os.environ,
+                    reason="This test is not run in Travis because there isn't a service account added yet")
 def test_k8s_db_cli():
     try:
         start_cmd = f"freenome-build db start-k8s"
@@ -102,10 +103,11 @@ def test_k8s_db_cli():
         run_and_log(stop_cmd)
         stop_cmd = f"freenome-build db --conn-string {conn_data2} stop-k8s"
         run_and_log(stop_cmd)
- 
+
 
 # TODO(travis_service_account)
-@pytest.mark.skip(reason="There's no google service account for travis yet")
+@pytest.mark.skipif('TRAVIS' in os.environ,
+                    reason="This test is not run in Travis because there isn't a service account added yet")
 def test_k8s_db_interface():
     try:
         conn_data, pod_id1 = start_k8s_database(DB_DIR, 'freenome_build')

--- a/tests/test_test_db.py
+++ b/tests/test_test_db.py
@@ -5,10 +5,12 @@ import pytest
 
 from freenome_build.db import (
     start_local_database,
+    start_k8s_database,
     setup_db,
     insert_test_data,
     reset_data,
     stop_local_database,
+    stop_k8s_database,
     DbConnectionData
 )
 from freenome_build.util import run_and_log
@@ -57,7 +59,7 @@ def test_docker_db_cli():
         stdout = subprocess.check_output(connect_cmd, shell=True, input=b"SELECT * FROM test; \q").decode().strip()
         assert stdout == "test \n------\n test\n(1 row)"
     finally:
-        stop_cmd = f"freenome-build db --conn-string {conn_string} stop"
+        stop_cmd = f"freenome-build db --conn-string {conn_string} stop-local"
         subprocess.check_call(stop_cmd, shell=True)
 
 
@@ -67,3 +69,50 @@ def test_db_module_interface():
     insert_test_data(conn_data, DB_DIR)
     reset_data(conn_data, DB_DIR)
     stop_local_database(conn_data)
+
+
+def _test_k8s_connection(testing_pod_id: str, conn_data: DbConnectionData):
+    # Try connecting with our new connection. pg_isready doesn't take connection
+    # strings so we need to take it apart a little.
+    run_and_log(f"kubectl exec {testing_pod_id} -- pg_isready -h {conn_data.host} "
+                f"-p {conn_data.port} -U {conn_data.user} -d {conn_data.dbname}")
+
+
+def test_k8s_db_cli():
+    try:
+        start_cmd = f"freenome-build db start-k8s"
+        start_response = subprocess.check_output(start_cmd, shell=True).decode().strip().split("\n")
+        conn_data1 = DbConnectionData.from_conn_string(start_response[0])
+
+        start_response = subprocess.check_output(start_cmd, shell=True).decode().strip().split("\n")
+        conn_data2 = DbConnectionData.from_conn_string(start_response[0])
+        pod_id2 = start_response[1]
+
+        # Modify our connection data so that we can get a new connection string with
+        # postgres as the user and database. We need to do this since the database doesn't
+        # have the user and database created yet.
+        conn_data1.user = 'postgres'
+        conn_data1.dbname = 'postgres'
+        _test_k8s_connection(pod_id2, conn_data1)
+    finally:
+        # Try stopping the database using their IPs instead of pod_ids
+        stop_cmd = f"freenome-build db --host {conn_data1.host} stop-k8s"
+        run_and_log(stop_cmd)
+        stop_cmd = f"freenome-build db --conn-string {conn_data2} stop-k8s"
+        run_and_log(stop_cmd)
+ 
+
+def test_k8s_db_interface():
+    try:
+        conn_data, pod_id1 = start_k8s_database(DB_DIR, 'freenome_build')
+        # Start a second container and see if we can communicate with the original one.
+        _, pod_id2 = start_k8s_database(DB_DIR, 'freenome_build')
+        # Modify our connection data so that we can get a new connection string with
+        # postgres as the user and database. We need to do this since the database doesn't
+        # have the user and database created yet.
+        conn_data.user = 'postgres'
+        conn_data.dbname = 'postgres'
+        _test_k8s_connection(pod_id2, conn_data)
+    finally:
+        stop_k8s_database(pod_id1)
+        stop_k8s_database(pod_id2)


### PR DESCRIPTION
Added freenome-build db start-k8s, start-k8s-test-db, and stop-k8s

This assumes that any kubernetes test db we create will want to run on port 5432 of its pod.

I'm a little torn on whether or not it would be better to create a k8s-db subparser especially since the insert and reset commands remain the same. Let me know your thoughts!