### PR TITLE
Added changes to kill any stopped containers with the same name

### DIFF
--- a/freenome_build/db.py
+++ b/freenome_build/db.py
@@ -65,7 +65,7 @@ def _execute_sql_script(sql_script_path, dbuser, dbname, host, port):
     pass
 
 
-def find_free_port():
+def _find_free_port():
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(('', 0))
         return s.getsockname()[1]
@@ -189,7 +189,7 @@ def start_local_database(repo_path: str, project_name: str, dbname: str = None, 
 
     # Find a free port if one wasn't specified
     if port is None:
-        port = find_free_port()
+        port = _find_free_port()
 
     if password is None:
         password = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(32)])

--- a/tests/test_test_db.py
+++ b/tests/test_test_db.py
@@ -11,8 +11,7 @@ from freenome_build.db import (
     reset_data,
     stop_local_database,
     stop_k8s_database,
-    DbConnectionData,
-    find_free_port
+    DbConnectionData
 )
 from freenome_build.util import run_and_log
 

--- a/tests/test_test_db.py
+++ b/tests/test_test_db.py
@@ -11,7 +11,8 @@ from freenome_build.db import (
     reset_data,
     stop_local_database,
     stop_k8s_database,
-    DbConnectionData
+    DbConnectionData,
+    find_free_port
 )
 from freenome_build.util import run_and_log
 
@@ -122,3 +123,10 @@ def test_k8s_db_interface():
     finally:
         stop_k8s_database(pod_id1)
         stop_k8s_database(pod_id2)
+
+
+def test_existing_db_container():
+    conn_data = start_local_database("/not/a/valid/path", "db_test")
+    # Stop the container and then try to create a container with the same port
+    run_and_log(f"docker stop {conn_data.dbname}_{conn_data.port}")
+    start_local_database("/not/a/valid/path", "db_test", dbname=conn_data.dbname, port=conn_data.port)


### PR DESCRIPTION
Fix for killing stopped database containers. This happened in the rare case the random free port was taken by a stopped container.
https://freenome.atlassian.net/browse/PIP-646