### PR TITLE
Add Makefile and get tests working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ install:
 - sudo cpanm --quiet --notest App::Sqitch
 cache: pip
 script:
-- python -m flake8 freenome_build
-- python -m pytest -vv
+- make lint
+- make test
 branches:
   only:
   - master

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SHELL = /bin/bash -o pipefail
+
+# Don't load virtualenv if we are already running in one.
+ifeq ($(VIRTUAL_ENV),)
+VIRTUALENV_PREAMBLE := . venv/bin/activate;
+endif
+
+venv:
+ifeq ($(VIRTUAL_ENV),)
+	pip install --upgrade pip
+	pip install --upgrade virtualenv
+	virtualenv --python=python3.6 venv
+endif
+
+install: venv
+	$(VIRTUALENV_PREAMBLE) pip install -r update_requirements.txt
+	# this adds additional packages; would be great to move to
+	# test-requirements.txt like the other packages.
+	$(VIRTUALENV_PREAMBLE) python setup.py install
+
+lint: venv
+	$(VIRTUALENV_PREAMBLE) python -m flake8 freenome_build
+
+test: venv
+	$(VIRTUALENV_PREAMBLE) python -m pytest --duration=0 tests
+
+bail: venv
+	$(VIRTUALENV_PREAMBLE) python -m pytest --maxfail=1 tests

--- a/README.md
+++ b/README.md
@@ -20,10 +20,22 @@ Running `freenome-build develop $REPO_PATH` sets up a development environment fo
    - if a meta.taml file exists in `$REPO_PATH/meta.yaml` then use that as the package specification
    - if not, use `python setup.py bdist_conda` to build the conda package
 2) install the built packages' dependencies by running `conda install $PACKAGE --only-deps`
-3) install the package in python's develop mode by running `python $REPO_PATH/setup.py develop` 
+3) install the package in python's develop mode by running `python $REPO_PATH/setup.py develop`
 
 ## freenome-build deploy -u -p $REPO_PATH
 Build the package in $REPO_PATH and upload to anaconda cloud. The -u flag asks freenome-build to upload to anaconda cloud in addition to packaging.
+
+## Local installation
+
+You will need Sqitch and the sqitch_pg plugin, which can be installed by cpan
+(and is in Travis). If you are using a Mac, you might find the Homebrew install
+easier:
+
+```
+brew tap theory/sqitch
+brew install theory/sqitch/sqitch
+brew install theory/sqitch/sqitch_pg
+```
 
 
 ## Caveats, gotchas, and TODO's

--- a/freenome_build/db.py
+++ b/freenome_build/db.py
@@ -205,7 +205,11 @@ def start_local_database(repo_path: str, project_name: str, dbname: str = None, 
     run_and_log(run_cmd)
 
     # Get the IP automatically
-    host = socket.gethostbyname(socket.gethostname())
+    try:
+        host = socket.gethostbyname(socket.gethostname())
+    except Exception:
+        # not everyone sets hostname, this is a good default
+        host = '127.0.0.1'
     # Wait for the db to start up before configuring it
     _wait_for_db_cluster_to_start(host, port)
 

--- a/update_requirements.txt
+++ b/update_requirements.txt
@@ -2,7 +2,6 @@ flake8
 PyYAML
 conda
 conda-build
-conda-verify
 anaconda-client
 psycopg2
 portalocker


### PR DESCRIPTION
The Makefile standardizes the install instructions across all of our
Python repos.

Some tests were referencing variables that might not have existed if
a command that ran before their declaration threw an error. Instead
define the variables to the null value and don't run the cleanups if
the variables are null.

Remove a package from update_requirements.txt that cannot be
installed.

Add instructions to the README on how to install dependencies.