### PR TITLE
Allow version to be detected by running setup.py --version

### DIFF
--- a/freenome_build/version_utils.py
+++ b/freenome_build/version_utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import subprocess
 
 from freenome_build import github
 
@@ -17,6 +18,10 @@ def version(path, repo_name=None):
     if repo_name is None:
         repo_name = github.repo_name()
 
+    version = get_version_from_setup_py(path)
+    if version is not None:
+        return version
+
     version_from_init = get_version_from_init(path, repo_name)
     version_from_version_file = get_version_from_version_file(path)
 
@@ -29,6 +34,13 @@ def version(path, repo_name=None):
         return version_from_version_file
     else:
         raise FileNotFoundError("Version file cannot be found.")
+
+
+def get_version_from_setup_py(path):
+    try:
+        return subprocess.check_output(["python", "setup.py", "--version"], cwd=path).strip()
+    except Exception:
+        return None
 
 
 def get_version_from_init(path, repo_name=None):

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -1,0 +1,13 @@
+import os.path
+
+import freenome_build.version_utils
+
+
+def test_get_version():
+    test_path = os.path.dirname(os.path.realpath(__file__))
+    path = os.path.abspath(os.path.join(test_path, '..'))
+    vsn = freenome_build.version_utils.get_version_from_setup_py(path)
+    assert vsn.count(b'.') == 2
+    # want to test something about the version string - just fix the test if we
+    # release version 3.
+    assert vsn[0] == '2'


### PR DESCRIPTION
This is a more portable way to detect the version since it defers the
decision to setup.py, which ensures it will be the same when we upload
new package versions by running setup.py directly, and when we use the
tools here.