### PR TITLE
install freenome-build into a test conda environment and add a deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
   - "/v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?/"
 deploy:
 - provider: script
-  script: freenome-build deploy -u
+  script: bash scripts/install_and_deploy.sh
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ services:
 - docker
 - postgresql
 install:
-- source scripts/install_latest_stable_freenome_build.sh $ANACONDA_TOKEN
+- source scripts/install_latest_stable_freenome_build.sh $ANACONDA_TOKEN freenome_build_env
+- source activate freenome_build_env
 - freenome-build develop .
 - sudo cpanm --quiet --notest App::Sqitch
 cache: pip

--- a/scripts/install_and_deploy.sh
+++ b/scripts/install_and_deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pushd ..
+    python setup.py develop
+    freenome-build deploy -u
+popd

--- a/scripts/install_and_deploy.sh
+++ b/scripts/install_and_deploy.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-pushd ..
-    python setup.py develop
-    freenome-build deploy -u
-popd
+python setup.py develop
+freenome-build deploy -u

--- a/scripts/install_latest_stable_freenome_build.sh
+++ b/scripts/install_latest_stable_freenome_build.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
 PYTHON_VERSION=3.6
+ANACONDA_TOKEN=$1
+BUILD_ENV=$2
+
+if [ -a $BUILD_ENV ]; then
+    BUILD_ENV=freenome_build_env
+fi
 
 set -eo pipefail
 
-ANACONDA_TOKEN=$1
 if [ $(uname) = 'Linux' ]; then
     MINICONDA_URL='https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh'
 elif [ $(uname) = 'Darwin' ]; then
@@ -31,8 +36,8 @@ pushd $MINICONDA_INSTALL_PATH
         conda install anaconda-client --yes
     fi
 
-    conda create -n freenome_build_env --yes python=${PYTHON_VERSION} || true
-    source activate freenome_build_env
+    conda create -n $BUILD_ENV --yes python=${PYTHON_VERSION} || true
+    source activate $BUILD_ENV
 
     # setup the condarc with the correct set of channels
     conda config --remove channels defaults || true
@@ -59,5 +64,5 @@ pushd $MINICONDA_INSTALL_PATH
         conda install freenome-build --yes
     fi
 
-    source deactivate build_env
+    source deactivate $BUILD_ENV
 popd

--- a/scripts/install_latest_stable_freenome_build.sh
+++ b/scripts/install_latest_stable_freenome_build.sh
@@ -36,7 +36,7 @@ pushd $MINICONDA_INSTALL_PATH
         conda install anaconda-client --yes
     fi
 
-    conda create -n $BUILD_ENV --yes python=${PYTHON_VERSION} || true
+    conda create -n $BUILD_ENV --yes python=${PYTHON_VERSION}
     source activate $BUILD_ENV
 
     # setup the condarc with the correct set of channels

--- a/scripts/install_latest_stable_freenome_build.sh
+++ b/scripts/install_latest_stable_freenome_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+PYTHON_VERSION=3.6
+
 set -eo pipefail
 
 ANACONDA_TOKEN=$1
@@ -29,6 +31,9 @@ pushd $MINICONDA_INSTALL_PATH
         conda install anaconda-client --yes
     fi
 
+    conda create -n freenome_build_env --yes python=${PYTHON_VERSION} || true
+    source activate freenome_build_env
+
     # setup the condarc with the correct set of channels
     conda config --remove channels defaults || true
     conda config --add channels https://repo.anaconda.com/pkgs/pro/
@@ -53,4 +58,6 @@ pushd $MINICONDA_INSTALL_PATH
     else
         conda install freenome-build --yes
     fi
+
+    source deactivate build_env
 popd

--- a/scripts/install_latest_stable_freenome_build_local.sh
+++ b/scripts/install_latest_stable_freenome_build_local.sh
@@ -90,4 +90,6 @@ conda activate
         " >> $RC_PATH
 fi
 
+source deactivate build_env
+
 popd;

--- a/scripts/install_latest_stable_freenome_build_local.sh
+++ b/scripts/install_latest_stable_freenome_build_local.sh
@@ -58,7 +58,7 @@ fi
 ANACONDA_TOKEN=$(anaconda auth --create --name $USER-admin-token)
 
 # create a local build environment
-conda create -n $BUILD_ENV --yes python=${PYTHON_VERSION} || true
+conda create -n $BUILD_ENV --yes python=${PYTHON_VERSION}
 source activate $BUILD_ENV
 
 # setup the condarc with the correct set of channels

--- a/scripts/install_latest_stable_freenome_build_local.sh
+++ b/scripts/install_latest_stable_freenome_build_local.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
 PYTHON_VERSION=3.6
+ANACONDA_TOKEN=$1
+BUILD_ENV=$2
+
+if [ -a $BUILD_ENV ]; then
+    BUILD_ENV=freenome_build_env
+fi
+
 
 isZsh() {
     if [ -n "$(ps -p "$$" | grep zsh)" ]; then
@@ -12,7 +19,6 @@ isZsh() {
 
 set -e
 
-ANACONDA_TOKEN=$1
 if [ $(uname) = 'Linux' ]; then
     MINICONDA_URL='https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh'
 elif [ $(uname) = 'Darwin' ]; then
@@ -52,8 +58,8 @@ fi
 ANACONDA_TOKEN=$(anaconda auth --create --name $USER-admin-token)
 
 # create a local build environment
-conda create -n freenome_build_env --yes python=${PYTHON_VERSION} || true
-source activate freenome_build_env
+conda create -n $BUILD_ENV --yes python=${PYTHON_VERSION} || true
+source activate $BUILD_ENV
 
 # setup the condarc with the correct set of channels
 conda config --remove channels defaults || true
@@ -90,6 +96,6 @@ conda activate
         " >> $RC_PATH
 fi
 
-source deactivate build_env
+source deactivate $BUILD_ENV
 
 popd;

--- a/scripts/install_latest_stable_freenome_build_local.sh
+++ b/scripts/install_latest_stable_freenome_build_local.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+PYTHON_VERSION=3.6
+
 isZsh() {
     if [ -n "$(ps -p "$$" | grep zsh)" ]; then
         return 0
@@ -48,6 +50,10 @@ else
 fi
 
 ANACONDA_TOKEN=$(anaconda auth --create --name $USER-admin-token)
+
+# create a local build environment
+conda create -n freenome_build_env --yes python=${PYTHON_VERSION} || true
+source activate freenome_build_env
 
 # setup the condarc with the correct set of channels
 conda config --remove channels defaults || true


### PR DESCRIPTION
The motivation behind this PR is around 2 possible issues that I've noticed with `freenome-build`.
1) `install_latest_stable_freenome_build.sh` and `install_latest_stable_freenome_build_local.sh` both install `freenome-build` into the global conda environment. I have modified this behavior to install into a `freenome_build_env` with a pinned python version.
2) expected `freenome-build` behavior in the past has been to run the most up-to-date package from conda. This is not necessarily the best behavior. I've added a script `scripts/install_and_deploy.sh` to install and deploy using `freenome-build` with a `git clone` command.