### PR TITLE
add the r channel to obtain requirements

### DIFF
--- a/scripts/install_latest_stable_freenome_build.sh
+++ b/scripts/install_latest_stable_freenome_build.sh
@@ -36,6 +36,7 @@ pushd $MINICONDA_INSTALL_PATH
     conda config --add channels https://repo.anaconda.com/pkgs/main/
     conda config --add channels conda-forge
     conda config --add channels bioconda
+    conda config --add channels r
     conda config --add channels https://conda.anaconda.org/t/$ANACONDA_TOKEN/freenome
 
     # install freenome-build. If we are building a new tag, assume it's a good

--- a/scripts/install_latest_stable_freenome_build_local.sh
+++ b/scripts/install_latest_stable_freenome_build_local.sh
@@ -56,6 +56,7 @@ conda config --add channels https://repo.anaconda.com/pkgs/free/
 conda config --add channels https://repo.anaconda.com/pkgs/main/
 conda config --add channels conda-forge
 conda config --add channels bioconda
+conda config --add channels r
 conda config --add channels https://conda.anaconda.org/t/$ANACONDA_TOKEN/freenome
 
 # install freenome-build


### PR DESCRIPTION
The R channel is required to install the `_r-mutex` dependency for `r-base` in balrog.